### PR TITLE
feat(authors): add list authors route

### DIFF
--- a/src/handlers/authors.rs
+++ b/src/handlers/authors.rs
@@ -36,4 +36,8 @@ impl Handler {
             .await?
             .ok_or(Error::AuthorNotFound(author_id))
     }
+
+    pub async fn list_authors(&self) -> Result<Vec<Author>> {
+        self.author_repository.list_authors().await
+    }
 }

--- a/src/repositories/authors.rs
+++ b/src/repositories/authors.rs
@@ -15,6 +15,7 @@ pub trait AuthorRepository {
         author_id: Uuid,
     ) -> Result<Option<Author>>;
     async fn delete_author_by_id(&self, author_id: Uuid) -> Result<Option<Author>>;
+    async fn list_authors(&self) -> Result<Vec<Author>>;
 }
 
 #[async_trait::async_trait]
@@ -86,5 +87,23 @@ impl AuthorRepository for SqlxRepository {
         .await?;
 
         Ok(rec)
+    }
+
+    async fn list_authors(&self) -> Result<Vec<Author>> {
+        let authors = sqlx::query_as!(
+            Author,
+            r#"
+            SELECT 
+                *
+            FROM 
+                AUTHORS 
+            WHERE 
+                DELETION_TIME IS NULL
+            "#
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(authors)
     }
 }

--- a/src/routes/authors.rs
+++ b/src/routes/authors.rs
@@ -21,7 +21,8 @@ pub(super) fn configure_routes() -> Router<Handler> {
             .route("/", post(create_author))
             .route("/:author_id", get(get_author_by_id))
             .route("/:author_id", patch(update_author_by_id))
-            .route("/:author_id", delete(delete_author_by_id)),
+            .route("/:author_id", delete(delete_author_by_id))
+            .route("/", get(list_authors)),
     )
 }
 
@@ -60,4 +61,10 @@ async fn delete_author_by_id(
     let author = handler.delete_author_by_id(author_id).await?;
 
     Ok(Json(author))
+}
+
+async fn list_authors(State(handler): State<Handler>) -> Result<impl IntoResponse> {
+    let authors = handler.list_authors().await?;
+
+    Ok(Json::from(authors))
 }


### PR DESCRIPTION
This PR implements the list authors route.

(GET) - /authors

return example:
`[
    {
        "authorId": "5296a55e-4908-4898-8d25-45b149441dd7",
        "name": "Gabriel",
        "dateOfBirth": "2024-07-22",
        "creationTime": "2024-02-23T01:25:04.350142Z"
    },
    {
        "authorId": "bf85826b-b773-4f6a-b746-647223cd79f5",
        "name": "Adriano",
        "dateOfBirth": "2024-07-22",
        "creationTime": "2024-02-23T14:02:10.733241Z",
        "updatedAt": "2024-02-23T14:02:24.178122Z"
    }
]`
