### PR TITLE
feat: add authors get_by_id test

### DIFF
--- a/src/repositories/authors.rs
+++ b/src/repositories/authors.rs
@@ -3,8 +3,10 @@ use crate::domain::{
     authors::{Author, CreateAuthor, UpdateAuthor},
     errors::Result,
 };
+use mockall::automock;
 use uuid::Uuid;
 
+#[automock]
 #[async_trait::async_trait]
 pub trait AuthorRepository {
     async fn create_author(&self, author: CreateAuthor) -> Result<Author>;

--- a/src/repositories/books.rs
+++ b/src/repositories/books.rs
@@ -1,3 +1,4 @@
+use mockall::automock;
 use uuid::Uuid;
 
 use crate::domain::{
@@ -7,6 +8,7 @@ use crate::domain::{
 
 use super::SqlxRepository;
 
+#[automock]
 #[async_trait::async_trait]
 pub trait BookRepository {
     async fn create_book(&self, book: CreateBook) -> Result<Book>;


### PR DESCRIPTION
This PR implements the test for the route:
GET: "/authors/:author_id"